### PR TITLE
Add basic CSP support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ arch:
     - python-flask-sqlalchemy
     - python-flask-wtf
     - python-flask-login
+    - python-flask-talisman
     - python-requests
     - python-scrypt
     - pyalpm

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ vulnerability details and generating security advisories.
 * python-sqlalchemy
 * python-flask
 * python-flask-sqlalchemy
+* python-flask-talisman
 * python-flask-wtf
 * python-flask-login
 * python-requests

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
+from flask_talisman import Talisman
 from werkzeug.routing import BaseConverter
 from types import MethodType
 from sqlalchemy.engine import Engine
@@ -24,9 +25,17 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
     dbapi_connection.isolation_level = isolation_level
 
 
+csp = {
+    'default-src': '\'self\'',
+    'style-src': '\'self\'',
+    'font-src': '\'self\'',
+    'form-action': '\'self\''
+}
+
 app = Flask(__name__)
 app.config.from_object('config')
 db = SQLAlchemy(app)
+talisman = Talisman(app, force_https=False, session_cookie_secure=False, content_security_policy=csp)
 
 login_manager = LoginManager()
 login_manager.init_app(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask
 Flask-Login
 Flask-SQLAlchemy
 Flask-WTF
+flask-talisman
 requests
 scrypt
 https://git.archlinux.org/users/remy/pyalpm.git/snapshot/pyalpm-0.8.tar.xz


### PR DESCRIPTION
Add Content Security Policy support using flask-talisman. By default
the force https and session_cookie_secure (forces cookies to be send over https)
options are enabled which break a normal `python run.py` on a local
machine, therefore they have been disabled.

CSP exceptions have been made for style, fonts served from external
source i.e. gooogle and form-action has been set as it's required for
form submission.