### PR TITLE
app: view: show: truncate summary length

### DIFF
--- a/app/view/show.py
+++ b/app/view/show.py
@@ -19,6 +19,10 @@ from jinja2.utils import escape
 
 
 def get_bug_data(cves, pkgs, group):
+
+    # the form's summary of bugs.archlinux.org has a maximum field length of 200
+    MAXLENGTH_SUMMARY = 200
+
     references = []
     references = [ref for ref in multiline_to_list(group.reference)
                   if ref not in references]
@@ -39,6 +43,9 @@ def get_bug_data(cves, pkgs, group):
     pkg_str = ' '.join((pkg.pkgname for pkg in pkgs))
     group_type = 'multiple issues' if len(unique_issue_types) > 1 else unique_issue_types[0]
     summary = '[{}] [Security] {} ({})'.format(pkg_str, group_type, ' '.join([cve.id for cve in cves]))
+
+    if len(summary) > MAXLENGTH_SUMMARY:
+        summary = "[{}] [Security] {} (Multiple CVE's)".format(pkg_str, group_type)
 
     # 5: critical, 4: high, 3: medium, 2: low, 1: very low.
     severitiy_mapping = {

--- a/app/view/show.py
+++ b/app/view/show.py
@@ -1,6 +1,6 @@
 from flask import render_template, redirect
 from sqlalchemy import and_
-from config import TRACKER_ADVISORY_URL, TRACKER_BUGTRACKER_URL, TRACKER_GROUP_URL, TRACKER_ISSUE_URL
+from config import TRACKER_ADVISORY_URL, TRACKER_BUGTRACKER_URL, TRACKER_GROUP_URL, TRACKER_ISSUE_URL, TRACKER_SUMMARY_LENGTH_MAX
 from app import app, db
 from app.util import json_response
 from app.user import user_can_edit_issue, user_can_delete_issue, user_can_edit_group, user_can_delete_group, user_can_handle_advisory
@@ -19,9 +19,6 @@ from jinja2.utils import escape
 
 
 def get_bug_data(cves, pkgs, group):
-
-    # the form's summary of bugs.archlinux.org has a maximum field length of 200
-    MAXLENGTH_SUMMARY = 200
 
     references = []
     references = [ref for ref in multiline_to_list(group.reference)
@@ -44,7 +41,7 @@ def get_bug_data(cves, pkgs, group):
     group_type = 'multiple issues' if len(unique_issue_types) > 1 else unique_issue_types[0]
     summary = '[{}] [Security] {} ({})'.format(pkg_str, group_type, ' '.join([cve.id for cve in cves]))
 
-    if len(summary) > MAXLENGTH_SUMMARY:
+    if TRACKER_SUMMARY_LENGTH_MAX != 0 and len(summary) > TRACKER_SUMMARY_LENGTH_MAX:
         summary = "[{}] [Security] {} (Multiple CVE's)".format(pkg_str, group_type)
 
     # 5: critical, 4: high, 3: medium, 2: low, 1: very low.

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ TRACKER_GROUP_URL = config_tracker['group_url']
 TRACKER_ISSUE_URL = config_tracker['issue_url']
 TRACKER_PASSWORD_LENGTH_MIN = config_tracker.getint('password_length_min')
 TRACKER_PASSWORD_LENGTH_MAX = config_tracker.getint('password_length_max')
+TRACKER_SUMMARY_LENGTH_MAX = config_tracker.getint('summary_length_max')
 
 config_sqlite = config['sqlite']
 SQLITE_JOURNAL_MODE = config_sqlite['journal_mode']

--- a/config/00-default.conf
+++ b/config/00-default.conf
@@ -6,6 +6,7 @@ bugtracker_url = https://bugs.archlinux.org/task/{0}
 mailman_url = https://lists.archlinux.org/pipermail/arch-security/
 password_length_min = 16
 password_length_max = 64
+summary_length_max = 200
 
 [pacman]
 handle_cache_time = 120


### PR DESCRIPTION
The form under bugs.archlinux.org has a maximum field length of 200. If
the length of the summary field computed is larger than this, the
propulated form will fail to submit, which requires the user (submitter)
to manually edit the summary field to have a shorter value.

Add a check to the get_bug_data function to use an alternative summary
if this length is exceeded.

(I personally had this issue when submitting the [zziplib](https://bugs.archlinux.org/task/53133) CVE's)