### PR TITLE
ui: switch package link from archweb query to direct

### DIFF
--- a/app/model/package.py
+++ b/app/model/package.py
@@ -40,7 +40,7 @@ def filter_duplicate_packages(packages, filter_arch=False):
 
 
 def sort_packages(packages):
-    packages = sorted(packages, key=lambda item: item.arch)
+    packages = sorted(packages, key=lambda item: item.arch, reverse=True)
     packages = sorted(packages, key=lambda item: item.database)
     packages = sorted(packages, key=cmp_to_key(vercmp, attrgetter('version')), reverse=True)
     return packages

--- a/app/templates/package.html
+++ b/app/templates/package.html
@@ -70,7 +70,12 @@
 					<tr>
 						<td>Link</td>
 						<td class="full size">
+							{% if package.versions[0] -%}
+							{%- set version = package.versions[0] -%}
+							<a href="https://www.archlinux.org/packages/{{version.database|urlencode}}/{{version.arch|urlencode}}/{{ package.pkgname|urlencode }}">package</a> |
+							{%- else -%}
 							<a href="https://www.archlinux.org/packages/?name={{ package.pkgname|urlencode }}">package</a> |
+							{%- endif %}
 							<a href="https://bugs.archlinux.org/?project=0&order=id&sort=desc&string={{ package.pkgname|urlencode }}">bugs open</a> |
 							<a href="https://bugs.archlinux.org/?project=0&order=id&sort=desc&status%5B%5D=closed&string={{ package.pkgname|urlencode }}">bugs closed</a> |
 							<a href="https://wiki.archlinux.org/index.php/Special:Search?search=%22{{ package.pkgname|urlencode }}%22">Wiki</a> |

--- a/app/view/show.py
+++ b/app/view/show.py
@@ -179,7 +179,7 @@ def get_group_data(avg):
     issue_types = list(issue_types)
     issues = sorted(issues, key=lambda item: item.id, reverse=True)
     packages = sorted(packages, key=lambda item: item.pkgname)
-    versions = sort_packages(filter_duplicate_packages(list(versions), True))
+    versions = filter_duplicate_packages(sort_packages(list(versions)), True)
     advisory_pending = group.status == Status.fixed and group.advisory_qualified and len(advisories) <= 0
 
     return {
@@ -307,7 +307,7 @@ def get_package_data(pkgname):
     groups = sorted(groups, key=lambda item: item.id, reverse=True)
     groups = sorted(groups, key=lambda item: item.status)
     advisories = sorted(advisories, key=lambda item: item.id, reverse=True)
-    versions = sort_packages(filter_duplicate_packages(list(versions), True))
+    versions = filter_duplicate_packages(sort_packages(list(versions)), True)
     package = versions[0] if versions else None
 
     return {


### PR DESCRIPTION
If there are version information available, use the first version
to create a direct archweb package link instead of using the
archweb search view.