### PR TITLE
cve: add tries to merge with existing entry

### DIFF
--- a/app/templates/form/cve.html
+++ b/app/templates/form/cve.html
@@ -2,7 +2,7 @@
 {% block content %}
 			<h1>{{ title }}</h1>
 			<div class="wide size">
-				<form action="" method="post" name="add">
+				<form action="{{ action }}" method="post" name="add">
 					{{ form.hidden_tag() }}
 					<div class="row">
 						<div class="one-half column">


### PR DESCRIPTION
If the CVE entry already exists, try to merge as much as possible
and warn about all unmerged fields.
This helps to edit issues when they are already added but not noticed.