### PR TITLE
ui: omit default 404 description

### DIFF
--- a/app/view/error.py
+++ b/app/view/error.py
@@ -19,7 +19,7 @@ def handle_error(e, code, json=False):
 
 @app.errorhandler(NotFound.code)
 def not_found(e='404: Not Found', json=False):
-    return handle_error(e, NotFound.code, json)
+    return handle_error(e if 'check your spelling' not in '{}'.format(e) else '404: Not Found', NotFound.code, json)
 
 
 @app.errorhandler(Forbidden.code)


### PR DESCRIPTION
The default 404 not-found description looks overly long and boring.
Lets just omit it when we find it, otherwise use the passed e param.