### PR TITLE
ui: disable CVE id field in edit mode

### DIFF
--- a/app/form/cve.py
+++ b/app/form/cve.py
@@ -15,3 +15,9 @@ class CVEForm(BaseForm):
     reference = TextAreaField(u'References', validators=[Optional(), Length(max=CVE.REFERENCES_LENGTH), ValidURLs()])
     notes = TextAreaField(u'Notes', validators=[Optional(), Length(max=CVE.NOTES_LENGTH)])
     submit = SubmitField(u'submit')
+
+    def __init__(self, edit=False):
+        super().__init__()
+        self.edit = edit
+        if edit:
+            self.cve.render_kw = {'readonly': True}

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -386,6 +386,10 @@ input[type="button"].button-primary:focus {
 	border-color: rgb(155, 187, 224);
 }
 
+input[readonly] {
+	background-color: #f1f1f1;
+}
+
 .button.button-table {
 	height: 2.2em;
 	line-height: 2.0em;

--- a/app/view/edit.py
+++ b/app/view/edit.py
@@ -73,7 +73,7 @@ def edit_cve(cve):
     if not user_can_edit_issue(advisories):
         return forbidden()
 
-    form = CVEForm()
+    form = CVEForm(edit=True)
     if not form.is_submitted():
         form.cve.data = cve.id
         form.issue_type.data = cve.issue_type


### PR DESCRIPTION
The CVE id field cannot be changed while editing. Therefor we mark
the field as readonly and visually display it.