### PR TITLE
copy: allow AVG and CVE entries to be copied into the add form

### DIFF
--- a/app/templates/cve.html
+++ b/app/templates/cve.html
@@ -3,6 +3,7 @@
 {% block content %}
 			<h1>{{ issue.id }}
 			{%- if can_edit %} <a href="/{{  issue.id }}/edit" accesskey="e">edit</a>{% endif %}
+			{%- if can_edit %} <a href="/{{  issue.id }}/copy" accesskey="c">copy</a>{% endif %}
 			{%- if can_delete %} <a href="/{{  issue.id }}/delete" accesskey="d">delete</a>{% endif %}</h1>
 			<table class="styled-table column-major full size">
 				<tbody>

--- a/app/templates/form/group.html
+++ b/app/templates/form/group.html
@@ -2,7 +2,7 @@
 {% block content %}
 			<h1>{{ title }}</h1>
 			<div class="wide size">
-				<form action="" method="post" name="add">
+				<form action="{{ action }}" method="post" name="add">
 					{{ form.hidden_tag() }}
 					<div class="row">
 						<div class="one-half column">

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -3,6 +3,7 @@
 {% block content %}
 			<h1>{{ group.name }}
 			{%- if can_edit %} <a href="/{{  group.name }}/edit" accesskey="e">edit</a>{% endif %}
+			{%- if can_edit %} <a href="/{{  group.name }}/copy" accesskey="c">copy</a>{% endif %}
 			{%- if can_delete %} <a href="/{{  group.name }}/delete" accesskey="d">delete</a>{% endif %}</h1>
 			<table class="styled-table column-major full size">
 				<tbody>

--- a/app/view/__init__.py
+++ b/app/view/__init__.py
@@ -2,6 +2,7 @@ from .add import *
 from .edit import *
 from .show import *
 from .delete import *
+from .copy import *
 
 from .index import *
 from .login import *

--- a/app/view/copy.py
+++ b/app/view/copy.py
@@ -1,0 +1,73 @@
+from flask import render_template
+from app import app, db
+from app.user import reporter_required
+from app.form import CVEForm, GroupForm
+from app.model import CVE, CVEGroup, CVEGroupPackage, CVEGroupEntry
+from app.model.cve import cve_id_regex
+from app.model.cvegroup import vulnerability_group_regex
+from app.model.enum import status_to_affected
+from app.view.error import not_found
+from itertools import chain
+from sqlalchemy import func
+
+
+@app.route('/issue/<regex("{}"):issue>/copy'.format(cve_id_regex[1:-1]), methods=['GET'])
+@app.route('/cve/<regex("{}"):issue>/copy'.format(cve_id_regex[1:-1]), methods=['GET'])
+@app.route('/<regex("{}"):issue>/copy'.format(cve_id_regex[1:-1]), methods=['GET'])
+@reporter_required
+def copy_issue(issue):
+    cve = db.get(CVE, id=issue)
+    if not cve:
+        return not_found()
+
+    form = CVEForm()
+    form.cve.data = cve.id
+    form.description.data = cve.description
+    form.issue_type.data = cve.issue_type
+    form.notes.data = cve.notes
+    form.reference.data = cve.reference
+    form.remote.data = cve.remote.name
+    form.severity.data = cve.severity.name
+
+    return render_template('form/cve.html',
+                           title='Add CVE',
+                           form=form,
+                           CVE=CVE,
+                           action='/cve/add')
+
+
+@app.route('/group/<regex("{}"):avg>/copy'.format(vulnerability_group_regex[1:-1]), methods=['GET'])
+@app.route('/avg/<regex("{}"):avg>/copy'.format(vulnerability_group_regex[1:-1]), methods=['GET'])
+@app.route('/<regex("{}"):avg>/copy'.format(vulnerability_group_regex[1:-1]), methods=['GET'])
+@reporter_required
+def copy_group(avg):
+    group_id = avg.replace('AVG-', '')
+    group_data = (db.session.query(CVEGroup, CVE, func.group_concat(CVEGroupPackage.pkgname, ' '))
+                  .filter(CVEGroup.id == group_id)
+                  .join(CVEGroupEntry).join(CVE).join(CVEGroupPackage)
+                  .group_by(CVEGroup.id).group_by(CVE.id)
+                  .order_by(CVE.id)).all()
+    if not group_data:
+        return not_found()
+
+    group = group_data[0][0]
+    issues = [cve for (group, cve, pkg) in group_data]
+    issue_ids = [cve.id for cve in issues]
+    pkgnames = set(chain.from_iterable([pkg.split(' ') for (group, cve, pkg) in group_data]))
+
+    form = GroupForm()
+    form.advisory_qualified.data = group.advisory_qualified
+    form.affected.data = group.affected
+    form.bug_ticket.data = group.bug_ticket
+    form.cve.data = '\n'.join(issue_ids)
+    form.fixed.data = group.fixed
+    form.notes.data = group.notes
+    form.pkgnames.data = '\n'.join(sorted(pkgnames))
+    form.reference.data = group.reference
+    form.status.data = status_to_affected(group.status).name
+
+    return render_template('form/group.html',
+                           title='Add AVG',
+                           form=form,
+                           CVEGroup=CVEGroup,
+                           action='/avg/add')

--- a/test/test_cve.py
+++ b/test/test_cve.py
@@ -157,6 +157,14 @@ def test_reporter_can_delete(db, client):
 
 @create_issue
 @logged_in(role=UserRole.reporter)
+def test_reporter_can_copy(db, client):
+    resp = client.get(url_for('copy_issue', issue=DEFAULT_ISSUE_ID), follow_redirects=True)
+    assert 200 == resp.status_code
+    assert ERROR_LOGIN_REQUIRED not in resp.data.decode()
+
+
+@create_issue
+@logged_in(role=UserRole.reporter)
 def test_abort_delete(db, client):
     resp = client.post(url_for('delete_issue', issue=DEFAULT_ISSUE_ID), follow_redirects=True,
                        data=dict(abort=True))
@@ -178,6 +186,12 @@ def test_delete_needs_login(db, client):
 
 
 @create_issue
+def test_copy_needs_login(db, client):
+    resp = client.get(url_for('copy_issue', issue=DEFAULT_ISSUE_ID), follow_redirects=True)
+    assert ERROR_LOGIN_REQUIRED in resp.data.decode()
+
+
+@create_issue
 def test_show_issue(db, client):
     resp = client.get(url_for('show_cve', cve=DEFAULT_ISSUE_ID, path=''))
     assert 200 == resp.status_code
@@ -194,6 +208,12 @@ def test_show_issue_not_found(db, client):
 def test_edit_issue_not_found(db, client):
     resp = client.post(url_for('edit_cve', cve='CVE-2011-0000'), follow_redirects=True,
                        data=default_issue_dict())
+    assert resp.status_code == NotFound.code
+
+
+@logged_in
+def test_copy_issue_not_found(db, client):
+    resp = client.get(url_for('copy_issue', issue='CVE-2011-0000', path=''), follow_redirects=True)
     assert resp.status_code == NotFound.code
 
 

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -61,6 +61,15 @@ def test_reporter_can_add(db, client):
 
 
 @create_package(name='foo')
+@create_group(packages=['foo'])
+@logged_in(role=UserRole.reporter)
+def test_reporter_can_copy(db, client):
+    resp = client.get(url_for('copy_group', avg=DEFAULT_GROUP_NAME), follow_redirects=True)
+    assert 200 == resp.status_code
+    assert ERROR_LOGIN_REQUIRED not in resp.data.decode()
+
+
+@create_package(name='foo')
 @logged_in
 def test_add_implicit_issue_creation(db, client):
     issue_id = 'CVE-4242-4242'
@@ -108,6 +117,12 @@ def test_edit_needs_login(db, client):
     assert ERROR_LOGIN_REQUIRED in resp.data.decode()
 
 
+@create_group
+def test_copy_needs_login(db, client):
+    resp = client.get(url_for('copy_group', avg=DEFAULT_GROUP_NAME), follow_redirects=True)
+    assert ERROR_LOGIN_REQUIRED in resp.data.decode()
+
+
 @logged_in
 def test_show_group_not_found(db, client):
     resp = client.get(url_for('show_group', avg='AVG-42'), follow_redirects=True)
@@ -117,6 +132,12 @@ def test_show_group_not_found(db, client):
 @logged_in
 def test_edit_group_not_found(db, client):
     resp = client.get(url_for('edit_group', avg='AVG-42'), follow_redirects=True)
+    assert resp.status_code == NotFound.code
+
+
+@logged_in
+def test_copy_group_not_found(db, client):
+    resp = client.get(url_for('copy_group', avg='AVG-42'), follow_redirects=True)
     assert resp.status_code == NotFound.code
 
 


### PR DESCRIPTION
This aids to copy certain entries for faster creation. The most
obvious use case is to copy an AVG from a non lib32 variant into
a lib32 variant without the hassle to fill in everything field
by field via copy-paste.