### PR TITLE
add pkgnames to title for the AVG and CVE view

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		{%- if title %}
-		<title>{{ title }} - Arch Linux Security Tracker</title>
+		<title>{{ title }} - Arch Linux</title>
 		{%- else %}
 		<title>Arch Linux Security Tracker</title>
 		{%- endif %}

--- a/app/view/show.py
+++ b/app/view/show.py
@@ -17,6 +17,7 @@ from app.util import chunks, multiline_to_list
 from collections import defaultdict, OrderedDict
 from jinja2.utils import escape
 
+
 def get_bug_project(databases):
     bug_project_mapping = {
         1: ['core', 'extra', 'testing'],
@@ -29,6 +30,7 @@ def get_bug_project(databases):
 
     # Fallback
     return 1
+
 
 def get_bug_data(cves, pkgs, versions, group):
     references = []
@@ -138,8 +140,14 @@ def show_cve(cve, path=None):
     data = get_cve_data(cve)
     if not data:
         return not_found()
+
+    packages = list(set(sorted([item for sublist in data['group_packages'].values() for item in sublist])))
+    title = '{} - {}'.format(data['issue'].id, ' '.join(packages)) \
+            if len(packages) else \
+            '{}'.format(data['issue'].id)
+
     return render_template('cve.html',
-                           title=data['issue'].id,
+                           title=title,
                            issue=data['issue'],
                            groups=data['groups'],
                            group_packages=data['group_packages'],
@@ -241,12 +249,13 @@ def show_group(avg):
     issue_types = data['issue_types']
     versions = data['versions']
     issue_type = 'multiple issues' if len(issue_types) > 1 else issue_types[0]
+    pkgnames = list(set(sorted([pkg.pkgname for pkg in packages])))
 
     form = AdvisoryForm()
     form.advisory_type.data = issue_type
 
     return render_template('group.html',
-                           title='{}'.format(group),
+                           title='{} - {}'.format(group, ' '.join(pkgnames)),
                            form=form,
                            group=group,
                            packages=packages,


### PR DESCRIPTION
add pkgnames the AVG and CVE view

examples:
``` 
AVG-4 - python-flask-something python2-flask-something - Arch Linux
AVG-123 - wireshark - Arch Linux
CVE-1234-1111 - bash zsh fish - Arch Linux
CVE-1234-2222 - bash - Arch Linux
CVE-1234-3333 - Arch Linux
```

When we add additional info to the title it actually becomes overly
long. We drop the tracker part of it has it doesn't add too much
information compared to which packages it they affect.