### PR TITLE
ui: don't show scheduled advisories for guests in AVG/CVE view

### DIFF
--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -61,7 +61,7 @@
 						<td>Created</td>
 						<td>{{ group.created.strftime('%c') }}</td>
 					</tr>
-					{%- if advisory_pending %}
+					{%- if advisories_pending %}
 					<tr>
 						<td>Advisory</td>
 						{%- if can_handle_advisory %}


### PR DESCRIPTION
This also fixes a visual issue for staff that displays a delete button
but it can't be used as deletion is forbidden when any advisories
exist referencing the AVG or CVE.