### PR TITLE
Added missing td elements

### DIFF
--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -99,6 +99,8 @@
 					<tr>
 						<td>Total</td>
 						<td>{{ issues.total }}</td>
+						<td>{{ issues.type.local.total }}</td>
+						<td>{{ issues.type.remote.total }}</td>
 						<td>{{ issues.type.vulnerable.total }}</td>
 						<td class="separator-right">{{ issues.type.fixed.total }}</td>
 						<td>{{ advisories.total }}</td>


### PR DESCRIPTION
The last row of the Types table in the stats.html template appeared to be missing the 'Local' and 'Remote' types for the last row containing totals of the values in the table. I'm not sure if this was intentional or not. 