### PR TITLE
Add a link to the advisories h1

### DIFF
--- a/app/templates/advisories.html
+++ b/app/templates/advisories.html
@@ -1,7 +1,9 @@
 {%- extends "base.html" -%}
 {%- from "_formhelpers.html" import nullable_value, colorize_severity, colorize_status, bug_ticket -%}
 {% block content %}
-			<h1>Advisories</h1>
+			<h1>Advisories
+				<a href="{{ url_for('advisory_atom') }}">feed</a>
+			</h1>
 			{%- if scheduled %}
 			<h2>Scheduled</h2>
 			<table class="styled-table medium size">


### PR DESCRIPTION
Include a link named "feed" to the advories h1 so that visitors can
figure out that we provide an atom feed for advisories.

An atom feed icon would also be possible, but this is easier!