### PR TITLE
advosry: fix change type accordingly if the group issues change

### DIFF
--- a/tracker/view/edit.py
+++ b/tracker/view/edit.py
@@ -166,14 +166,14 @@ def edit_group(avg):
                   .filter(CVEGroup.id == group_id)
                   .join(CVEGroupEntry).join(CVE).join(CVEGroupPackage)
                   .outerjoin(Advisory, Advisory.group_package_id == CVEGroupPackage.id)
-                  .group_by(CVEGroup.id).group_by(CVE.id)
+                  .group_by(CVEGroup.id).group_by(CVE.id).group_by(CVEGroupPackage.pkgname)
                   .order_by(CVE.id)).all()
     if not group_data:
         return not_found()
 
     group = group_data[0][0]
-    issues = [cve for (group, cve, pkg, advisory) in group_data]
-    issue_ids = [cve.id for cve in issues]
+    issues = set([cve for (group, cve, pkg, advisory) in group_data])
+    issue_ids = set([cve.id for cve in issues])
     pkgnames = set(chain.from_iterable([pkg.split(' ') for (group, cve, pkg, advisory) in group_data]))
     advisories = set(advisory for (group, cve, pkg, advisory) in group_data if advisory)
 


### PR DESCRIPTION
Change the advisory issue type accordingly when adding or removing
CVE entries from a group that has already scheduled multiple advisories
because its multi package.

The issue was a missing group-by on the pkgname which resulted in only
selecting one of the multiple advisories that got scheduled and the
others kept its old advisory issue types when it should have been
changed.

This fixes #100