### PR TITLE
view: overwrite urlize filter that populates CVE and AVG links

### DIFF
--- a/test/test_cve.py
+++ b/test/test_cve.py
@@ -321,3 +321,25 @@ def test_add_cve_does_not_overwrite_existing_cve(db, client):
     assert 'foobar' == cve.description
     assert 'https://archlinux.org\nhttps://security.archlinux.org' == cve.reference
     assert 'the cake is a lie' == cve.notes
+
+
+@create_issue(description='foo AVG-1 bar CVE-1234-5678 qux https://foo.bar doo CVE-1337-1337.')
+def test_show_issue_urlize_description(db, client):
+    resp = client.get(url_for('tracker.show_cve', cve=DEFAULT_ISSUE_ID, path=''))
+    assert 200 == resp.status_code
+    data = resp.data.decode()
+    assert 'foo <a href="/{0}">{0}</a> bar'.format('AVG-1') in data
+    assert 'bar <a href="/{0}">{0}</a> qux'.format('CVE-1234-5678') in data
+    assert 'qux <a href="{0}" rel="noopener">{0}</a> doo'.format('https://foo.bar') in data
+    assert 'doo <a href="/{0}">{0}</a>.'.format('CVE-1337-1337') in data
+
+
+@create_issue(notes='foo AVG-1 bar CVE-1234-5678 qux https://foo.bar doo CVE-1337-1337.')
+def test_show_issue_urlize_notes(db, client):
+    resp = client.get(url_for('tracker.show_cve', cve=DEFAULT_ISSUE_ID, path=''))
+    assert 200 == resp.status_code
+    data = resp.data.decode()
+    assert 'foo <a href="/{0}">{0}</a> bar'.format('AVG-1') in data
+    assert 'bar <a href="/{0}">{0}</a> qux'.format('CVE-1234-5678') in data
+    assert 'qux <a href="{0}" rel="noopener">{0}</a> doo'.format('https://foo.bar') in data
+    assert 'doo <a href="/{0}">{0}</a>.'.format('CVE-1337-1337') in data

--- a/tracker/advisory.py
+++ b/tracker/advisory.py
@@ -1,6 +1,5 @@
 from datetime import date
 from datetime import datetime
-from functools import cmp_to_key
 from html import unescape
 from re import IGNORECASE
 from re import search
@@ -73,10 +72,6 @@ def advisory_get_workaround_from_text(advisory):
 
 
 def advisory_extend_html(advisory, issues, package):
-    # sort issues by length to avoid clashes
-    issues = sorted(issues, key=cmp_to_key(lambda a, b: len(a.id) - len(b.id)), reverse=True)
-    for issue in issues:
-        advisory = advisory.replace(' {}'.format(issue.id), ' <a href="/{0}">{0}</a>'.format(issue.id))
     advisory = sub('({}) '.format(package.pkgname), '<a href="/package/{0}">\g<1></a> '.format(package.pkgname), advisory, flags=IGNORECASE)
     advisory = sub(' ({})'.format(package.pkgname), ' <a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
     advisory = sub(';({})'.format(package.pkgname), ';<a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)

--- a/tracker/templates/cve.html
+++ b/tracker/templates/cve.html
@@ -61,7 +61,7 @@
 					</tr>
 					<tr>
 						<td>Description</td>
-						<td><pre>{{ nullable_value(issue.description) }}</pre></td>
+						<td><pre>{{ nullable_value(issue.description)|urlize }}</pre></td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
This fixes #97