### PR TITLE
test: Special characters break advisory generation

### DIFF
--- a/test/test_advisory.py
+++ b/test/test_advisory.py
@@ -290,6 +290,19 @@ def test_advisory_html_overlapping_cve_link(db, client):
     assert '<a href="/{0}">{0}</a>'.format('CVE-1234-12345') in data
 
 
+@create_package(name='crypto++', version='1.2.3-4')
+@create_issue(description='crypto++ is broken and crypto++.')
+@create_group(id=DEFAULT_GROUP_ID, packages=['crypto++'], affected='1.2.3-3', fixed='1.2.3-4', issues=[DEFAULT_ISSUE_ID])
+@create_advisory(id=DEFAULT_ADVISORY_ID, group_package_id=DEFAULT_GROUP_ID, advisory_type=issue_types[1])
+@logged_in
+def test_advisory_html_regex_keyword_in_package_name(db, client):
+    resp = client.get(url_for('tracker.show_generated_advisory', advisory_id=DEFAULT_ADVISORY_ID), follow_redirects=True)
+    assert 200 == resp.status_code
+    data = resp.data.decode()
+    assert '<a href="/package/crypto++">crypto++</a> is broken' in data
+    assert 'and <a href="/package/crypto++">crypto++</a>' in data
+
+
 @create_package(name='foo', version='1.2.3-4')
 @create_issue(id='CVE-1234-1234')
 @create_issue(id='CVE-1234-12345')

--- a/tracker/advisory.py
+++ b/tracker/advisory.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from functools import cmp_to_key
 from html import unescape
 from re import IGNORECASE
+from re import escape
 from re import search
 from re import sub
 
@@ -77,9 +78,10 @@ def advisory_extend_html(advisory, issues, package):
     issues = sorted(issues, key=cmp_to_key(lambda a, b: len(a.id) - len(b.id)), reverse=True)
     for issue in issues:
         advisory = advisory.replace(' {}'.format(issue.id), ' <a href="/{0}">{0}</a>'.format(issue.id))
-    advisory = sub('({}) '.format(package.pkgname), '<a href="/package/{0}">\g<1></a> '.format(package.pkgname), advisory, flags=IGNORECASE)
-    advisory = sub(' ({})'.format(package.pkgname), ' <a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
-    advisory = sub(';({})'.format(package.pkgname), ';<a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
+
+    advisory = sub('({}) '.format(escape(package.pkgname)), '<a href="/package/{0}">\g<1></a> '.format(package.pkgname), advisory, flags=IGNORECASE)
+    advisory = sub(' ({})'.format(escape(package.pkgname)), ' <a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
+    advisory = sub(';({})'.format(escape(package.pkgname)), ';<a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
     return advisory
 
 


### PR DESCRIPTION
crypto++ breaks the advisory generation, since it has a '++' in it's
package name which should be escaped for use in sub().

Closes #107