### PR TITLE
advisory: align varying length issue listing nicely

### DIFF
--- a/tracker/model/cve.py
+++ b/tracker/model/cve.py
@@ -1,4 +1,5 @@
 from tracker import db
+from tracker.util import issue_to_numeric
 
 from .enum import Remote
 from .enum import Severity
@@ -59,8 +60,7 @@ class CVE(db.Model):
 
     @property
     def numerical_repr(self):
-        self_parts = self.id.split('-')
-        return int(self_parts[1] + self_parts[2].rjust(7, '0'))
+        return issue_to_numeric(self.id)
 
     def __gt__(self, other):
         return self.numerical_repr > other.numerical_repr

--- a/tracker/templates/advisory.txt
+++ b/tracker/templates/advisory.txt
@@ -7,7 +7,7 @@ Subject: [{{ advisory.id }}] {{ package.pkgname }}: {{ advisory.advisory_type }}
 
 Severity: {{ group.severity }}
 Date    : {{ advisory.created.strftime('%Y-%m-%d') }}
-CVE-ID  : {{ issues_listing_formatted }}
+CVE-ID  : {{ issue_listing_formatted }}
 Package : {{ package.pkgname }}
 Type    : {{ advisory.advisory_type }}
 Remote  : {%if not remote %}No{% else %}Yes{% endif %}

--- a/tracker/util.py
+++ b/tracker/util.py
@@ -80,3 +80,8 @@ def atom_feed(title):
             return func(*args, **kwargs)
         return wrapped
     return decorator
+
+
+def issue_to_numeric(issue_label):
+    self_parts = issue_label.split('-')
+    return int(self_parts[1] + self_parts[2].rjust(7, '0'))

--- a/tracker/view/edit.py
+++ b/tracker/view/edit.py
@@ -33,6 +33,7 @@ from tracker.user import reporter_required
 from tracker.user import security_team_required
 from tracker.user import user_can_edit_group
 from tracker.user import user_can_edit_issue
+from tracker.util import issue_to_numeric
 from tracker.util import multiline_to_list
 from tracker.view.error import forbidden
 from tracker.view.error import not_found
@@ -191,6 +192,7 @@ def edit_group(avg):
         form.bug_ticket.data = group.bug_ticket
         form.advisory_qualified.data = group.advisory_qualified and group.status is not Status.not_affected
 
+        issue_ids = sorted(issue_ids, key=issue_to_numeric)
         form.cve.data = "\n".join(issue_ids)
     if not form.validate_on_submit():
         if advisories:

--- a/tracker/view/show.py
+++ b/tracker/view/show.py
@@ -15,6 +15,7 @@ from config import TRACKER_SUMMARY_LENGTH_MAX
 from tracker import db
 from tracker import tracker
 from tracker.advisory import advisory_extend_html
+from tracker.advisory import advisory_format_issue_listing
 from tracker.form.advisory import AdvisoryForm
 from tracker.model import CVE
 from tracker.model import Advisory
@@ -36,7 +37,6 @@ from tracker.user import user_can_delete_issue
 from tracker.user import user_can_edit_group
 from tracker.user import user_can_edit_issue
 from tracker.user import user_can_handle_advisory
-from tracker.util import chunks
 from tracker.util import json_response
 from tracker.util import multiline_to_list
 from tracker.view.error import not_found
@@ -515,10 +515,9 @@ def show_generated_advisory(advisory_id, raw=False):
     issues = sorted([issue for (advisory, group, package, issue) in entries])
     severity_sorted_issues = sorted(issues, key=lambda issue: issue.issue_type)
     severity_sorted_issues = sorted(severity_sorted_issues, key=lambda issue: issue.severity)
-
     remote = any([issue.remote is Remote.remote for issue in issues])
-    issues_listing_formatted = (('\n{}'.format(' ' * len('CVE-ID  : ')))
-                                .join(list(map(' '.join, chunks([issue.id for issue in issues], 4)))))
+    issue_listing_formatted = advisory_format_issue_listing([issue.id for issue in issues])
+
     link = TRACKER_ADVISORY_URL.format(advisory.id, group.id)
     upstream_released = group.affected.split('-')[0].split('+')[0] != group.fixed.split('-')[0].split('+')[0]
     upstream_version = group.fixed.split('-')[0].split('+')[0]
@@ -543,7 +542,7 @@ def show_generated_advisory(advisory_id, raw=False):
                               package=package,
                               issues=issues,
                               remote=remote,
-                              issues_listing_formatted=issues_listing_formatted,
+                              issue_listing_formatted=issue_listing_formatted,
                               link=link,
                               workaround=advisory.workaround,
                               impact=advisory.impact,


### PR DESCRIPTION
Multiple CVEs with varying length make advisory CVE header section
unaligned. Split the issues into columns and rows and align each
column individually to be nicely unter each other.

Fixes #94