### PR TITLE
cve: added cve.circl.lu to our cve link collection

### DIFF
--- a/tracker/templates/cve.html
+++ b/tracker/templates/cve.html
@@ -20,6 +20,7 @@
 										<li><a href="https://people.canonical.com/~ubuntu-security/cve/{{ issue.id }}">Ubuntu</a></li>
 										<li><a href="https://www.suse.com/security/cve/{{ issue.id }}">SUSE</a></li>
 										<li><a href="https://www.cvedetails.com/cve-details.php?cve_id={{ issue.id }}">CVE Details</a></li>
+										<li><a href="https://cve.circl.lu/cve/{{ issue.id }}">CIRCL</a></li>
 									</ul>
 								</li>
 								<li>Bugs


### PR DESCRIPTION
cve.circl.lu is hosted by the CERT of luxembourg.
They provide a full JSON API for receiving CVEs from multiple feeds
like:

* NIST National Vulnerability Database
* Common Platform Enumeration (CPE)
* Common Weakness Enumeration (CWE)
* CIRCL incident statistics and threat ranking
* toolswatch/vFeed