### PR TITLE
tracker: Fix 500 on /todo/json

### DIFF
--- a/tracker/view/todo.py
+++ b/tracker/view/todo.py
@@ -155,7 +155,7 @@ def group_packages_json(item):
     entry['status'] = group.status.label
     entry['severity'] = group.severity.label
     entry['affected'] = group.affected
-    entry['packages'] = list(packages)
+    entry['packages'] = [pkg if type(pkg) == str else pkg.name for pkg in packages]
     return entry
 
 


### PR DESCRIPTION
The unknown groups the packages list contains Package objects and not
strings, therefore add a check and return the correct serializable type.