### PR TITLE
Updated regex to better highlight affected package names

### DIFF
--- a/tracker/advisory.py
+++ b/tracker/advisory.py
@@ -75,9 +75,7 @@ def advisory_get_workaround_from_text(advisory):
 
 
 def advisory_extend_html(advisory, issues, package):
-    advisory = sub('({}) '.format(escape(package.pkgname)), '<a href="/package/{0}">\g<1></a> '.format(package.pkgname), advisory, flags=IGNORECASE)
-    advisory = sub(' ({})'.format(escape(package.pkgname)), ' <a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
-    advisory = sub(';({})'.format(escape(package.pkgname)), ';<a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
+    advisory = sub(r'(\b({0})\b)'.format(escape(package.pkgname)), '<a href="/package/{0}">\g<1></a>'.format(package.pkgname), advisory, flags=IGNORECASE)
     return advisory
 
 


### PR DESCRIPTION
Modifed the regex used to better link affected package names, partial matches will no longer match. 
Ex: "abc" will pass in "abc" but fail in "abcd" or "12abc34" 