### PR TITLE
OTP authentication draft

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,6 +34,8 @@ TRACKER_ISSUE_URL = config_tracker['issue_url']
 TRACKER_PASSWORD_LENGTH_MIN = config_tracker.getint('password_length_min')
 TRACKER_PASSWORD_LENGTH_MAX = config_tracker.getint('password_length_max')
 TRACKER_SUMMARY_LENGTH_MAX = config_tracker.getint('summary_length_max')
+TRACKER_OTP_FORMAT = config_tracker['otp_format']
+TRACKER_ENABLE_TWO_FACTOR = config_tracker.getboolean('enable_two_factor')
 
 config_sqlite = config['sqlite']
 SQLITE_JOURNAL_MODE = config_sqlite['journal_mode']

--- a/config/00-default.conf
+++ b/config/00-default.conf
@@ -7,6 +7,8 @@ mailman_url = https://lists.archlinux.org/pipermail/arch-security/
 password_length_min = 16
 password_length_max = 64
 summary_length_max = 200
+otp_format = otpauth://totp/Security Tracker:{0}?secret={1}&issuer=Arch Linux
+enable_two_factor = on
 
 [pacman]
 handle_cache_time = 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ flask-talisman
 requests
 scrypt
 https://git.archlinux.org/pyalpm.git/snapshot/pyalpm-0.8.4.tar.gz
+Flask-QRcode
+pyotp

--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -6,6 +6,7 @@ from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_talisman import Talisman
+from flask_qrcode import QRcode
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.sql.expression import ClauseElement
@@ -66,7 +67,8 @@ csp = {
     'default-src': '\'self\'',
     'style-src': '\'self\'',
     'font-src': '\'self\'',
-    'form-action': '\'self\''
+    'form-action': '\'self\'',
+    'img-src': 'data:'
 }
 
 db = SQLAlchemy()
@@ -86,6 +88,7 @@ def create_app(script_info=None):
 
     db.init_app(app)
     migrate.init_app(app)
+    QRcode(app)
 
     talisman.init_app(app,
                       force_https=False,

--- a/tracker/form/__init__.py
+++ b/tracker/form/__init__.py
@@ -1,3 +1,4 @@
 from .cve import CVEForm
 from .group import GroupForm
 from .login import LoginForm
+from .login import OTPForm

--- a/tracker/model/user.py
+++ b/tracker/model/user.py
@@ -12,6 +12,7 @@ class User(db.Model):
     SALT_LENGTH = 20
     PASSWORD_LENGTH = 80
     TOKEN_LENGTH = 120
+    OTP_TOKEN_LENGTH = 16
 
     __tablename__ = 'user'
     id = db.Column(db.Integer(), index=True, unique=True, primary_key=True, autoincrement=True)
@@ -22,9 +23,12 @@ class User(db.Model):
     token = db.Column(db.String(TOKEN_LENGTH), index=True, unique=True, nullable=True)
     role = db.Column(UserRole.as_type(), nullable=False, default=UserRole.reporter)
     active = db.Column(db.Boolean(), nullable=False, default=True)
+    otp_token = db.Column(db.String(OTP_TOKEN_LENGTH), index=True, nullable=True)
 
     is_authenticated = False
     is_anonymous = False
+
+    first_time_login_otp = False
 
     @property
     def is_active(self):

--- a/tracker/templates/two_factor.html
+++ b/tracker/templates/two_factor.html
@@ -1,0 +1,18 @@
+{%- extends "base.html" -%}
+{% block content %}
+			<h1>Two Factor</h1>
+            {% if display_qr %}
+                <img src="{{ qrcode(otp_string) }}">
+            {%endif%}  
+			<div class="tiny size">
+				<form action="" method="post" name="login">
+					{{ form.hidden_tag() }}
+					<div class="row">
+						<div class="single columns">
+							{{ render_field(form.otp_code, class='full size', placeholder='OTP Code', autofocus='', required='', indent=7) }}
+						</div>
+					</div>
+					{{ form.login(class='button-primary') }}
+				</form>
+			</div>
+{%- endblock %}

--- a/tracker/view/login.py
+++ b/tracker/view/login.py
@@ -60,8 +60,8 @@ def two_factor():
                                title='Two Factor Login',
                                User=User,
                                form=form,
-                               display_qr=current_user.first_time_login_otp,
-                               otp_string=TRACKER_OTP_FORMAT.format(current_user.name, current_user.otp_token),
+                               display_qr=user.first_time_login_otp,
+                               otp_string=TRACKER_OTP_FORMAT.format(user.name, user.otp_token),
                                otp_code_length={'max': 6}), status_code
 
     user = user_assign_new_token(user)

--- a/tracker/view/login.py
+++ b/tracker/view/login.py
@@ -1,6 +1,9 @@
+import pyotp
+
 from flask import redirect
 from flask import render_template
 from flask import url_for
+from flask import session
 from flask_login import current_user
 from flask_login import login_user
 from flask_login import logout_user
@@ -8,8 +11,11 @@ from werkzeug.exceptions import Unauthorized
 
 from config import TRACKER_PASSWORD_LENGTH_MAX
 from config import TRACKER_PASSWORD_LENGTH_MIN
+from config import TRACKER_OTP_FORMAT
+from config import TRACKER_ENABLE_TWO_FACTOR
 from tracker import tracker
 from tracker.form import LoginForm
+from tracker.form import OTPForm
 from tracker.model.user import User
 from tracker.user import user_assign_new_token
 from tracker.user import user_invalidate
@@ -18,7 +24,7 @@ from tracker.user import user_invalidate
 @tracker.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
-        return redirect(url_for('tracker.index'))
+        return redirect(url_for('tracker.two_factor'))
 
     form = LoginForm()
     if not form.validate_on_submit():
@@ -29,9 +35,36 @@ def login():
                                User=User,
                                password_length={'min': TRACKER_PASSWORD_LENGTH_MIN,
                                                 'max': TRACKER_PASSWORD_LENGTH_MAX}), status_code
-
+    if TRACKER_ENABLE_TWO_FACTOR:
+        session['two_factor'] = form.user.name
+        return redirect(url_for('tracker.two_factor'))
     user = user_assign_new_token(form.user)
-    user.is_authenticated = True
+    login_user(user)
+    return redirect(url_for('tracker.index'))
+
+
+@tracker.route('/twofactor', methods=['GET', 'POST'])
+def two_factor():
+    if current_user.is_authenticated:
+        return redirect(url_for('tracker.index'))
+    if not session.get('two_factor'):
+        return redirect(url_for('tracker.login'))
+    user = User.query.filter(User.name == session['two_factor']).first()
+    if not user.otp_token:
+        user.otp_token = pyotp.random_base32()
+        user.first_time_login_otp = True
+    form = OTPForm()
+    if not form.validate_on_submit():
+        status_code = Unauthorized.code if form.is_submitted() else 200
+        return render_template('two_factor.html',
+                               title='Two Factor Login',
+                               User=User,
+                               form=form,
+                               display_qr=current_user.first_time_login_otp,
+                               otp_string=TRACKER_OTP_FORMAT.format(current_user.name, current_user.otp_token),
+                               otp_code_length={'max': 6}), status_code
+
+    user = user_assign_new_token(user)
     login_user(user)
     return redirect(url_for('tracker.index'))
 


### PR DESCRIPTION
This introduces a WIP OTP authentication login mechanism for the
tracker. This introduces a hack, and proves a possible implementation
error.

The views themselves can not change the `is_authorized` attribute. Only
the `load_user` function in `user.py` does this as our only check is on
`current_user`. This function is only creating `current_user` after the
initial `login_user(user)` call done after successfully verification.

Any calls to `login_user(user)` will authenticate the session and no
partial session can be created. To get around this we check if OTP
authentication is enabled, then create a session variable `two_factor`
which is checked inside the view and form to prompt further
authentication.

Signed-off-by: Morten Linderud <morten@linderud.pw>