### PR TITLE
ui: make HTML parsing test happy

### DIFF
--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -1,6 +1,5 @@
 {%- from "_formhelpers.html" import render_field, render_field_unlabeled, render_checkbox -%}
-<!DOCTYPE html>
-<html>
+<!DOCTYPE html><html>
 	<head>
 		{%- if title %}
 		<title>{{ title }} - Arch Linux</title>


### PR DESCRIPTION
The newline after the DOCTYPE declaration triggers
an extra handle_data() call.