### PR TITLE
disabled hsts header

### DIFF
--- a/config.py
+++ b/config.py
@@ -55,6 +55,7 @@ FLASK_HOST = config_flask['host']
 FLASK_PORT = config_flask.getint('port')
 FLASK_SESSION_PROTECTION = None if 'none' == config_flask['session_protection'] else config_flask['session_protection']
 set_debug_flag(config_flask.getboolean('debug'))
+FLASK_STRICT_TRANSPORT_SECURITY = config_flask.getboolean('strict_transport_security')
 
 config_pacman = config['pacman']
 PACMAN_HANDLE_CACHE_TIME = config_pacman.getint('handle_cache_time')

--- a/config/00-default.conf
+++ b/config/00-default.conf
@@ -18,6 +18,7 @@ debug = off
 secret_key = changeme_iddqd
 csrf = on
 session_protection  = strong
+strict_transport_security = off
 
 [sqlalchemy]
 echo = no

--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -12,6 +12,7 @@ from sqlalchemy.sql.expression import ClauseElement
 from werkzeug.routing import BaseConverter
 
 from config import FLASK_SESSION_PROTECTION
+from config import FLASK_STRICT_TRANSPORT_SECURITY
 from config import SQLALCHEMY_MIGRATE_REPO
 from config import SQLITE_CACHE_SIZE
 from config import SQLITE_JOURNAL_MODE
@@ -75,7 +76,7 @@ db.create = MethodType(db_create, db)
 db.get_or_create = MethodType(db_get_or_create, db)
 
 migrate = Migrate(db=db, directory=SQLALCHEMY_MIGRATE_REPO)
-talisman = Talisman()
+talisman = Talisman(strict_transport_security=FLASK_STRICT_TRANSPORT_SECURITY)
 login_manager = LoginManager()
 tracker = Blueprint('tracker', __name__)
 


### PR DESCRIPTION
Currently we set two HSTS headers. One in `flask-talisman` and one in
our nginx configuration. This is bad, mhhhhkaaaaay. So let's disable our
hsts header in `flask-talisman` and let's nginx do its job. This closes #150 

Signed-off-by: Christian Rebischke <chris@nullday.de>