### PR TITLE
Advisory review system

### DIFF
--- a/tracker/form/review.py
+++ b/tracker/form/review.py
@@ -1,0 +1,26 @@
+from wtforms import SubmitField
+from wtforms import TextAreaField
+from wtforms.validators import Length
+from wtforms.validators import Optional
+
+from tracker.model.review import Review
+
+from .base import BaseForm
+
+class ReviewForm(BaseForm):
+    note = TextAreaField(u'Notes', validators=[Optional(), Length(max=Review.NOTE_LENGTH)])
+    approve = SubmitField(u'approve')
+    revoke = SubmitField(u'disapprove')
+
+    def __init__(self, edit=False):
+        super().__init__()
+
+    def validate(self):
+        rv = BaseForm.validate(self)
+        if not rv:
+            return False
+
+        if self.revoke.data and not self.note.data:
+            return False
+
+        return True

--- a/tracker/model/__init__.py
+++ b/tracker/model/__init__.py
@@ -5,3 +5,4 @@ from .cvegroupentry import CVEGroupEntry
 from .cvegrouppackage import CVEGroupPackage
 from .package import Package
 from .user import User
+from .review import Review

--- a/tracker/model/review.py
+++ b/tracker/model/review.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from tracker import db
+
+
+class Review(db.Model):
+
+    NOTE_LENGTH = 4096
+
+    __tablename__ = 'review'
+    id = db.Column(db.Integer(), index=True, unique=True, primary_key=True, autoincrement=True)
+    user = db.relationship('User') 
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    advisory = db.relationship('Advisory')
+    advisory_id = db.Column(db.Integer, db.ForeignKey('advisory.id'))
+    created = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+    approved = db.Column(db.Boolean, default=False)
+    note = db.Column(db.String(NOTE_LENGTH))

--- a/tracker/templates/advisory.html
+++ b/tracker/templates/advisory.html
@@ -17,18 +17,48 @@
 				{%- endif %}
 				<a href="/{{  advisory.id }}/{% if generated %}generate/{% endif %}raw" accesskey="r">raw</a>
 			</h1>
-			<table class="styled-table full size">
-				<thead>
-					<tr>
-						<th>[{{ advisory.id }}] {{package.pkgname}}: {{advisory.advisory_type}}</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<div class='advisory'>{{ raw_asa|safe|urlize }}</div>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			<div class="row">
+				<div class="one-half column">
+					<table class="styled-table full size">
+						<thead>
+							<tr>
+								<th>[{{ advisory.id }}] {{package.pkgname}}: {{advisory.advisory_type}}</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>
+									<div class='advisory'>{{ raw_asa|safe|urlize }}</div>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+
+				{%- if current_user.is_authenticated and form %}
+				<div class="one-half column">
+					<table class="styled-table full size">
+						<thead>
+							<tr>
+								<th>Advisory reviews</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for review in reviews %}
+							<tr>
+								<td>{{review.user.name}} - {%- if review.approved %} <span class="green">Approved</span> {%- else %} <span class="red">Disapproved</span> {%- endif %} - {{review.note}}</td>
+							</tr>
+							{%- endfor %}
+						</tbody>
+					</table>
+
+				<form action="{{ action }}" method="post" name="add">
+					{{ form.hidden_tag() }}
+					{{ render_field(form.note, class='full size', maxlength=Review.NOTE_LENGTH, placeholder='Feedback...') }}
+					{{ form.approve(class='button-primary', accesskey='a') }}
+					{{ form.revoke(class='button-primary', accesskey='d') }}
+				</form>
+				</div>
+				{%- endif %}
+			</div>
 {%- endblock %}


### PR DESCRIPTION
Added a small review system to the advisory page. It lets anyone authenticated to write reviews for advisories. It inserts previous written reviews, and lets you modify the existing ones if anything comes up.

There is no inherent logic to this so any arbitrary rules (2 reviews needed etc) needs to be decided with the team.

The UI will probably need some work. @jelly mentioned it might not be a good idea to have it on the same page as the advisory, but I didn't have any better idea at the moment.

#### TODO

- [ ] Needs to be rebased on top of the audit branch
- [ ] The UX needs to be revisited


### Approve
![approved](https://ptpb.pw/52QU)

### Disapprove
![approved](https://ptpb.pw/EXpd)