### PR TITLE
requirements: move pyalpm to pypi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Flask-WTF
 flask-talisman
 requests
 scrypt
-https://git.archlinux.org/pyalpm.git/snapshot/pyalpm-0.8.5.tar.gz
+pyalpm


### PR DESCRIPTION
There doesn't seem to be a pyalpm 0.8.5 on the git.archlinux.org
repository. This is because the pyalpm develoment moved to github, and
releases are now published on pypi. Change the requirements.txt file to
use the pypi version of pyalpm.