### PR TITLE
tracker: add security splash page as index

### DIFF
--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -34,7 +34,8 @@
 		<div class="content">
 			<div class="navbar">
 				<ul>
-					<li><a href="/">issues</a></li>
+					<li><a href="/">Home</a></li>
+					<li><a href="/issues/">issues</a></li>
 					<li><a href="/advisory">advisories</a></li>
 					<li><a href="/todo">todo</a></li>
 					<li><a href="/stats">stats</a></li>

--- a/tracker/templates/security.html
+++ b/tracker/templates/security.html
@@ -1,0 +1,40 @@
+{%- extends "base.html" -%}
+{% block content %}
+
+    <h1>Arch Linux Security</h2>
+
+    For Arch Linux security is paramount, and a dedicated team of staffers and
+    volunteers helps with triaging, prioritizing, confirming, patching and
+    notifying about vulnerabilities in Arch Linux components as well as
+    packages provided in the official repositories.
+
+    <h2>Reporting Vulnerablities in Arch Linux Components or Infrastructure</h3>
+
+    If you have discovered a vulnerability in packages related to core
+    components or in Arch Linux infrastructure don't hesitate to reach out 
+    to <a href="mailto:security@archlinux.org">security@archlinux.org</a> to
+    discuss remediation. You can encrypt your email to the following gpg keys.
+    <!-- FIXME: we'll have to figure this one out on the backend -->
+    <ul>
+       <li><a href="https://www.archlinux.org/people/developers/#anthraxx">Levente Polyak</a>
+           <tt>E240 B57E 2C46 30BA 768E  2F26 FC1B 547C 8D81 72C8</tt></li>
+
+       <li><a href="https://www.archlinux.org/people/support-staff/#rgacogne">Remi Gacogne</a>
+           <tt>A4CB EA79 7489 8599 195E  4FEC 46EC 46F3 9F3E 2EF1</tt></li>
+
+       <li><a href="https://www.archlinux.org/people/developers/#allan">Allan McRae</a>
+           <tt>6645 B0A8 C700 5E78 DB1D  7864 F99F FE0F EAE9 99BD</tt></li>
+    </ul>
+
+    <h2>Vulnerabilities in Upstream Packages</h3>
+
+    Our <a href="https://security.archlinux.org/issues/">CVE tracker</a> can help you
+    review the vulnerabilities that affect the packages we provide. If you
+    think a CVE that affects a package is not listed in there, do not hesitate
+    to reach out to us in irc on <tt>#archlinux-security</tt>.
+
+    <h2>Securing your Arch Linux installation</h3>
+
+    Consider checking this 
+    <a href="https://wiki.archlinux.org/security/">Wiki page for more information</a>
+{%- endblock %}

--- a/tracker/view/__init__.py
+++ b/tracker/view/__init__.py
@@ -11,3 +11,4 @@ from .show import *
 from .stats import *
 from .todo import *
 from .user import *
+from .security import *

--- a/tracker/view/index.py
+++ b/tracker/view/index.py
@@ -53,7 +53,6 @@ def get_index_data(only_vulnerable=False, only_in_repo=True):
     return groups
 
 
-@tracker.route('/', defaults={'path': '', 'only_vulnerable': True}, methods=['GET'])
 def index(only_vulnerable=True, path=None):
     groups = get_index_data(only_vulnerable)
     return render_template('index.html',

--- a/tracker/view/security.py
+++ b/tracker/view/security.py
@@ -1,0 +1,6 @@
+from flask import render_template
+from tracker import tracker
+
+@tracker.route('/', methods=['GET'])
+def security():
+    return render_template('security.html')


### PR DESCRIPTION
More information on how to submit vulnerablities on arch linux
components and infrastructure, as well as how to report issues with
packages is necessary to ease the vulnerablity disclosure process.

Some previous discussion happened [here](https://github.com/archlinux/archweb/pull/223)