### PR TITLE
Make atom feeds great again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__/
+asset/
 tracker.db
-tracker.db-shm
-tracker.db-wal
+tracker.db*
 .cache
 .virtualenv
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__/
-asset/
 tracker.db
 tracker.db*
 .cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ archlinux:
     - python-flask-login
     - python-flask-migrate
     - python-flask-talisman
+    - python-feedgen
+    - python-pytz
     - python-requests
     - python-scrypt
     - pyalpm

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ vulnerability details and generating security advisories.
 * python-flask-migrate
 * python-requests
 * python-scrypt
+* python-feedgen
+* python-pytz
 * pyalpm
 * sqlite
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ requests
 scrypt
 pyalpm
 SQLAlchemy-Continuum
+feedgen
+pytz

--- a/test/test_advisory.py
+++ b/test/test_advisory.py
@@ -342,10 +342,8 @@ def test_advisory_cve_listing_sorted_numerically(db, client):
 
 def test_advisory_atom_no_data(db, client):
     resp = client.get(url_for('tracker.advisory_atom'), follow_redirects=True)
-    assert 404 == resp.status_code
-    # TODO: re-enable feed test
-    # data = resp.data.decode()
-    # assert DEFAULT_ADVISORY_ID not in data
+    data = resp.data.decode()
+    assert DEFAULT_ADVISORY_ID not in data
 
 
 @create_package(name='foo', version='1.2.3-4')
@@ -353,10 +351,8 @@ def test_advisory_atom_no_data(db, client):
 @create_advisory(id=DEFAULT_ADVISORY_ID, group_package_id=DEFAULT_GROUP_ID, advisory_type=issue_types[1], reference='https://security.archlinux.org', publication=Publication.published)
 def test_advisory_atom(db, client):
     resp = client.get(url_for('tracker.advisory_atom'), follow_redirects=True)
-    assert 404 == resp.status_code
-    # TODO: re-enable feed test
-    # data = resp.data.decode()
-    # assert DEFAULT_ADVISORY_ID in data
+    data = resp.data.decode()
+    assert DEFAULT_ADVISORY_ID in data
 
 
 def test_advisory_json_no_data(db, client):

--- a/test/test_advisory.py
+++ b/test/test_advisory.py
@@ -342,6 +342,7 @@ def test_advisory_cve_listing_sorted_numerically(db, client):
 
 def test_advisory_atom_no_data(db, client):
     resp = client.get(url_for('tracker.advisory_atom'), follow_redirects=True)
+    assert 200 == resp.status_code
     data = resp.data.decode()
     assert DEFAULT_ADVISORY_ID not in data
 
@@ -351,6 +352,7 @@ def test_advisory_atom_no_data(db, client):
 @create_advisory(id=DEFAULT_ADVISORY_ID, group_package_id=DEFAULT_GROUP_ID, advisory_type=issue_types[1], reference='https://security.archlinux.org', publication=Publication.published)
 def test_advisory_atom(db, client):
     resp = client.get(url_for('tracker.advisory_atom'), follow_redirects=True)
+    assert 200 == resp.status_code
     data = resp.data.decode()
     assert DEFAULT_ADVISORY_ID in data
 

--- a/tracker/static/feed.svg
+++ b/tracker/static/feed.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+<defs>
+<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
+<stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
+<stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
+<stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
+<stop  offset="1.0" stop-color="#D95B29"/>
+</linearGradient>
+</defs>
+<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
+<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
+<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
+<circle cx="68" cy="189" r="24" fill="#FFF"/>
+<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
+<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+</svg>

--- a/tracker/templates/advisories.html
+++ b/tracker/templates/advisories.html
@@ -2,7 +2,7 @@
 {%- from "_formhelpers.html" import nullable_value, colorize_severity, colorize_status, bug_ticket -%}
 {% block content %}
 			<h1>Advisories
-				<a href="{{ url_for('tracker.advisory_atom') }}">feed</a>
+                <a href="{{ url_for('tracker.advisory_atom') }}"><img src="/static/feed.svg" alt="rss feed" height="18" width="18" /></a>
 			</h1>
 			{%- if scheduled %}
 			<h2>Scheduled</h2>

--- a/tracker/templates/advisories.html
+++ b/tracker/templates/advisories.html
@@ -2,7 +2,7 @@
 {%- from "_formhelpers.html" import nullable_value, colorize_severity, colorize_status, bug_ticket -%}
 {% block content %}
 			<h1>Advisories
-                <a href="{{ url_for('tracker.advisory_atom') }}"><img src="/static/feed.svg" alt="rss feed" height="18" width="18" /></a>
+				<a href="{{ url_for('tracker.advisory_atom') }}"><img src="/static/feed.svg" alt="rss feed" height="18" width="18" /></a>
 			</h1>
 			{%- if scheduled %}
 			<h2>Scheduled</h2>

--- a/tracker/view/advisory.py
+++ b/tracker/view/advisory.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
 from re import match
 
-import pytz
 from feedgen.feed import FeedGenerator
 from flask import flash
 from flask import make_response
 from flask import redirect
 from flask import render_template
 from flask import request
+from pytz import UTC
 from sqlalchemy import and_
 
 from config import TRACKER_ISSUE_URL
@@ -62,7 +62,6 @@ def get_advisory_data():
 def advisory_atom():
     last_recent_entries = 15
     data = get_advisory_data()['published'][:last_recent_entries]
-
     feed = FeedGenerator()
     feed.title('Arch Linux Security - Recent advisories')
     feed.description('Arch Linux recent advsisories RSS feed')
@@ -73,7 +72,7 @@ def advisory_atom():
         advisory = entry['advisory']
         content=render_template('feed.html', content=advisory.content)
         summary=render_template('feed.html', content=advisory.impact)
-        published = updated = advisory.created.replace(tzinfo=pytz.UTC)
+        published = updated = advisory.created.replace(tzinfo=UTC)
 
         entry = feed.add_entry()
         entry.title(f'[{advisory.id}] {package.pkgname}: {advisory.advisory_type}')

--- a/tracker/view/advisory.py
+++ b/tracker/view/advisory.py
@@ -8,7 +8,6 @@ from flask import make_response
 from flask import redirect
 from flask import render_template
 from flask import request
-
 from sqlalchemy import and_
 
 from config import TRACKER_ISSUE_URL
@@ -34,10 +33,8 @@ from tracker.util import atom_feed
 from tracker.util import json_response
 from tracker.view.error import not_found
 
-
 ERROR_ADVISORY_GROUP_NOT_FIXED = 'AVG is not fixed yet.'
 ERROR_ADVISORY_ALREADY_EXISTS = 'Advisory already exists.'
-
 
 def get_advisory_data():
     entries = (db.session.query(Advisory, CVEGroup, CVEGroupPackage)


### PR DESCRIPTION
This uses feedgen to provide atom feeds after werkzeugs atom_feed got deprecated. Fixed #61 on the same run.