### PR TITLE
cve: check user_can_edit_issue before attempting to merge a CVE

### DIFF
--- a/tracker/view/edit.py
+++ b/tracker/view/edit.py
@@ -41,6 +41,7 @@ from tracker.view.error import forbidden
 from tracker.view.error import not_found
 
 WARNING_ADVISORY_ALREADY_PUBLISHED = 'WARNING: This advisory is already published!'
+ERROR_ISSUE_REFERENCED_BY_ADVISORY = 'Insufficient permissions to edit {} that is referenced by an already published advisory!'
 
 
 @tracker.route('/advisory/<regex("{}"):advisory_id>/edit'.format(advisory_regex[1:-1]), methods=['GET', 'POST'])
@@ -101,6 +102,7 @@ def edit_cve(cve):
     advisories = set(advisory for (cve, group, advisory) in entries if advisory)
 
     if not user_can_edit_issue(advisories):
+        flash(ERROR_ISSUE_REFERENCED_BY_ADVISORY.format(cve.id), 'error')
         return forbidden()
 
     form = CVEForm(edit=True)


### PR DESCRIPTION
`add_cve` [requires reporter permissions](https://github.com/archlinux/arch-security-tracker/blob/1037e20554e472697268d06fbcba4c9498f9c991/tracker/view/add.py#L30), but does not perform any further checks when attempting to merge with an existing CVE. This allows reporters a limited amount of control over CVEs for which advisories were already created, which should be denied by using [`user_can_edit_issue`](https://github.com/archlinux/arch-security-tracker/blob/1037e20554e472697268d06fbcba4c9498f9c991/tracker/user.py#L66-L72) like [`edit_cve` does](https://github.com/archlinux/arch-security-tracker/blob/1037e20554e472697268d06fbcba4c9498f9c991/tracker/view/edit.py#L103-L104).