### PR TITLE
fix: use sqlalchemy 1.3.0 to avoid startup issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ email_validator
 requests
 scrypt
 pyalpm
+sqlalchemy==1.3
 SQLAlchemy-Continuum
 feedgen
 pytz


### PR DESCRIPTION
While picking up work an the SSO issue again, I had some trouble getting the application to run at all:
```
λ ~/c/arch-security-tracker (master) make
git submodule update --recursive --init --rebase
./trackerctl setup bootstrap
Traceback (most recent call last):
  File "./trackerctl", line 5, in <module>
    cli.main()
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/flask/cli.py", line 586, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/flask/cli.py", line 425, in decorator
    with __ctx.ensure_object(ScriptInfo).load_app().app_context():
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/flask/cli.py", line 381, in load_app
    app = call_factory(self, self.create_app)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/flask/cli.py", line 113, in call_factory
    return app_factory(*arguments, script_info=script_info)
  File "/home/felix/code/arch-security-tracker/tracker/__init__.py", line 95, in create_app
    orm.configure_mappers()
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy/orm/mapper.py", line 3354, in configure_mappers
    _configure_registries(_all_registries(), cascade=True)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy/orm/mapper.py", line 3387, in _configure_registries
    Mapper.dispatch._for_class(Mapper).after_configured()
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy/event/attr.py", line 256, in __call__
    fn(*args, **kw)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy/orm/events.py", line 743, in wrap
    fn(*arg, **kw)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy_continuum/builder.py", line 163, in configure_versioned_classes
    self.build_transaction_class()
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy_continuum/builder.py", line 141, in build_transaction_class
    self.manager.create_transaction_model()
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy_continuum/manager.py", line 166, in create_transaction_model
    self.transaction_cls = self.transaction_cls(self)
  File "/home/felix/.pyenv/versions/3.7.0/lib/python3.7/site-packages/sqlalchemy_continuum/factory.py", line 9, in __call__
    registry = manager.declarative_base._decl_class_registry
AttributeError: type object 'Model' has no attribute '_decl_class_registry'
make: *** [Makefile:26: setup] Error 1
```

I finally realized that this happens due to pip defaulting to the latest sqlalchemy package:
```
λ ~/c/arch-security-tracker (master) pip list
Package              Version
-------------------- ---------
alembic              1.5.8
certifi              2020.12.5
chardet              4.0.0
click                7.1.2
dnspython            2.1.0
email-validator      1.1.2
feedgen              0.9.0
Flask                1.1.2
Flask-Login          0.5.0
Flask-Migrate        2.7.0
Flask-SQLAlchemy     2.5.1
flask-talisman       0.7.0
Flask-WTF            0.14.3
greenlet             1.0.0
idna                 2.10
importlib-metadata   3.10.1
itsdangerous         1.1.0
Jinja2               2.11.3
lxml                 4.6.3
Mako                 1.1.4
MarkupSafe           1.1.1
pip                  21.0.1
pyalpm               0.9.2
python-dateutil      2.8.1
python-editor        1.0.4
pytz                 2021.1
requests             2.25.1
scrypt               0.8.17
setuptools           39.0.1
six                  1.15.0
SQLAlchemy           1.4.7
SQLAlchemy-Continuum 1.3.11
SQLAlchemy-Utils     0.37.0
typing-extensions    3.7.4.3
urllib3              1.26.4
Werkzeug             1.0.1
WTForms              2.3.3
zipp                 3.4.1
```

This tiny PR fixes the sqlalchemy to 1.3.0, and thus removes this setup issue.
I didn't find a bug for that.