### PR TITLE
fix(db): automatically stamp the alembic migrate on db init

### DIFF
--- a/tracker/cli/db.py
+++ b/tracker/cli/db.py
@@ -1,9 +1,14 @@
+from os.path import exists
+from os.path import join
+
 from click import echo
 from click import option
 from click import pass_context
 from flask.cli import with_appcontext
+from flask_migrate import stamp
 from flask_migrate.cli import db as db_cli
 
+from config import basedir
 from tracker import db
 
 
@@ -47,7 +52,10 @@ def initdb(ctx, purge):
         ctx.invoke(drop)
 
     echo('Initializing database...', nl=False)
+    db_exists = exists(join(basedir, 'tracker.db'))
     db.create_all()
+    if not db_exists:
+        stamp()
     echo('done')
 
 


### PR DESCRIPTION
If a new database is initialized the alembic meta data is not
automatically stamped to the latest head. This leads to issues when
trying to create migration scripts. As a fix we automatically stamp the
alembic meta data to the current migration scripts head if the database
did not exist before.

This however does not automatically fix existing databases that lack the
alembic meta data stamp. Those should only affect some dev systems and
instead of carrying around some patch paths, we expect devs to simply
call ./trackerctl db stamp head

Fixes #182