### PR TITLE
requirements: force sqlalchemy 1.3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ requests
 scrypt
 pyalpm
 SQLAlchemy-Continuum
+SQLAlchemy~=1.3.0
 feedgen
 pytz


### PR DESCRIPTION
It seems that newer versions of sqlalchemy aren't supported, and break
the build/test. Force a minor version of 1.3 for it to ensure
requirements.txt installs works properly.