### PR TITLE
Drop not_skip option from isort configuration

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,3 @@
 [settings]
-not_skip = __init__.py
 force_single_line = 1
 skip = migrations/env.py


### PR DESCRIPTION
Since 5.0.0 the `not_skip` configuration option changed so it's no
longer the same as `--dont-skip`, secondly isort no longer skips
__init__.py by default.