### PR TITLE
Fix #197 jinja deprecation issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
           pacman -Syu --noconfirm git make python python-authlib python-isort python-pytest python-pytest-cov
           python-sqlalchemy python-sqlalchemy-continuum python-flask python-flask-sqlalchemy python-flask-wtf
           python-flask-login python-flask-migrate python-flask-talisman python-email-validator python-feedgen
-          python-pytz python-requests python-scrypt pyalpm sqlite
+          python-pytz python-requests python-scrypt python-markupsafe pyalpm sqlite
       - uses: actions/checkout@v2
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ vulnerability details and generating security advisories.
 * python-scrypt
 * python-feedgen
 * python-pytz
+* python-markupsafe
 * pyalpm
 * sqlite
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ SQLAlchemy~=1.3.0
 feedgen
 pytz
 authlib
+MarkupSafe

--- a/test/test_advisory.py
+++ b/test/test_advisory.py
@@ -2,7 +2,7 @@
 from collections import namedtuple
 
 from flask import url_for
-from jinja2.utils import escape
+from markupsafe import escape
 from pytest import mark
 from werkzeug.exceptions import Forbidden
 from werkzeug.exceptions import NotFound

--- a/tracker/advisory.py
+++ b/tracker/advisory.py
@@ -6,7 +6,7 @@ from re import escape
 from re import search
 from re import sub
 
-from jinja2.utils import escape as html_escape
+from markupsafe import escape as html_escape
 from requests import get
 
 from config import TRACKER_MAILMAN_URL
@@ -41,7 +41,7 @@ def advisory_fetch_reference_url_from_mailman(advisory):
         for line in response.text.split('\n'):
             if not '[{}]'.format(advisory.id) in line:
                 continue
-            match = search('HREF="(\d+.html)"', line)
+            match = search(r'HREF="(\d+.html)"', line)
             if not match:
                 continue
             return '{}{}'.format(mailman_url, match.group(1))

--- a/tracker/view/blueprint.py
+++ b/tracker/view/blueprint.py
@@ -5,9 +5,9 @@ from flask import Blueprint
 from flask import request
 from flask import url_for
 from jinja2.filters import do_urlize
-from jinja2.filters import evalcontextfilter
-from jinja2.utils import Markup
-from jinja2.utils import escape
+from jinja2.filters import pass_eval_context
+from markupsafe import Markup
+from markupsafe import escape
 
 from tracker.model.cve import cve_id_regex
 from tracker.model.cvegroup import vulnerability_group_regex
@@ -37,7 +37,7 @@ def smartindent(s, width=1, indentfirst=False, indentchar=u'\t'):
     return rv
 
 
-@evalcontextfilter
+@pass_eval_context
 @blueprint.app_template_filter()
 def urlize(ctx, text, trim_url_limit=None, rel=None, target=None):
     """Converts any URLs in text into clickable links. Works on http://,

--- a/tracker/view/show.py
+++ b/tracker/view/show.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from flask import redirect
 from flask import render_template
 from flask_login import current_user
-from jinja2.utils import escape
+from markupsafe import escape
 from sqlalchemy import and_
 from sqlalchemy_continuum import version_class
 from sqlalchemy_continuum import versioning_manager


### PR DESCRIPTION
Fixes the deprecation warnings of jinja2.markup, jinja2.escape and one regex that has not been upgraded to python3.