### PR TITLE
tracker: accept kwargs in Forms

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -87,7 +87,6 @@ def run_migrations_online():
     context.configure(connection=connection,
                       target_metadata=target_metadata,
                       process_revision_directives=process_revision_directives,
-                      render_as_batch=True,
                       **current_app.extensions['migrate'].configure_args)
 
     try:

--- a/tracker/form/admin.py
+++ b/tracker/form/admin.py
@@ -36,8 +36,8 @@ class UserForm(BaseForm):
         super().__init__()
         self.edit = edit
 
-    def validate(self):
-        rv = BaseForm.validate(self)
+    def validate(self, **kwargs):
+        rv = BaseForm.validate(self, kwargs)
         if not rv:
             return False
 

--- a/tracker/form/group.py
+++ b/tracker/form/group.py
@@ -41,8 +41,8 @@ class GroupForm(BaseForm):
         super().__init__()
         self.packages = packages
 
-    def validate(self):
-        rv = BaseForm.validate(self)
+    def validate(self, **kwargs):
+        rv = BaseForm.validate(self, kwargs)
         if not rv:
             return False
         if self.fixed.data and 0 <= vercmp(self.affected.data, self.fixed.data):

--- a/tracker/form/login.py
+++ b/tracker/form/login.py
@@ -24,9 +24,9 @@ class LoginForm(BaseForm):
     password = PasswordField(u'Password', validators=[DataRequired(), Length(min=TRACKER_PASSWORD_LENGTH_MIN, max=TRACKER_PASSWORD_LENGTH_MAX)])
     login = SubmitField(u'login')
 
-    def validate(self):
+    def validate(self, **kwargs):
         self.user = None
-        rv = BaseForm.validate(self)
+        rv = BaseForm.validate(self, kwargs)
         if not rv:
             return False
 

--- a/tracker/form/user.py
+++ b/tracker/form/user.py
@@ -26,8 +26,8 @@ class UserPasswordForm(BaseForm):
     def __init__(self, edit=False):
         super().__init__()
 
-    def validate(self):
-        rv = BaseForm.validate(self)
+    def validate(self, **kwargs):
+        rv = BaseForm.validate(self, kwargs)
         if not rv:
             return False
 


### PR DESCRIPTION
WTForms now accepts keyword arguments in validate() since 1.1.0


See https://github.com/wtforms/flask-wtf/issues/547 https://github.com/inveniosoftware/flask-security-fork/issues/51