### PR TITLE
Add group creation date to issues and group json

### DIFF
--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import url_for
 from werkzeug.exceptions import Forbidden
 from werkzeug.exceptions import NotFound
@@ -338,7 +340,7 @@ def test_show_group(db, client):
     assert 'text/html; charset=utf-8' == resp.content_type
     assert DEFAULT_GROUP_NAME in resp.data.decode()
 
-@create_group(id=DEFAULT_GROUP_ID, packages=['foo'], affected='1.2.3-3', fixed='1.2.3-4')
+@create_group(id=DEFAULT_GROUP_ID, created=datetime(2023, 5, 10), packages=['foo'], affected='1.2.3-3', fixed='1.2.3-4')
 @create_advisory(id=DEFAULT_ADVISORY_ID, group_package_id=DEFAULT_GROUP_ID, advisory_type=issue_types[1])
 def test_show_group_json(db, client):
     resp = client.get(url_for('tracker.show_group_json', avg=DEFAULT_GROUP_NAME, postfix='/json'), follow_redirects=True)
@@ -346,6 +348,7 @@ def test_show_group_json(db, client):
     assert 'application/json; charset=utf-8' == resp.content_type
     data = resp.get_json()
     assert data['name'] == DEFAULT_GROUP_NAME
+    assert data['date'] == '2023-05-10'
     assert data['issues'] == [DEFAULT_ISSUE_ID]
     assert data['packages'] == ['foo']
     assert data['affected'] == '1.2.3-3'

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import url_for
 
 from .conftest import DEFAULT_GROUP_ID
@@ -32,7 +34,7 @@ def test_index_all(db, client):
 
 
 @create_package(name='foo', version='1.2.3-4')
-@create_group(id=DEFAULT_GROUP_ID, packages=['foo'], affected='1.2.3-3')
+@create_group(id=DEFAULT_GROUP_ID, created=datetime(2023, 5, 10), packages=['foo'], affected='1.2.3-3')
 def test_index_json(db, client):
     resp = client.get(url_for('tracker.index_json', only_vulernable=False), follow_redirects=True)
     assert 200 == resp.status_code
@@ -40,13 +42,15 @@ def test_index_json(db, client):
     assert 'application/json; charset=utf-8' == resp.content_type
     assert len(data) == 1
     assert data[0]['name'] == DEFAULT_GROUP_NAME
+    assert data[0]['date'] == '2023-05-10'
 
 
 @create_package(name='foo', version='1.2.3-4')
-@create_group(id=DEFAULT_GROUP_ID, packages=['foo'], affected='1.2.3-3')
+@create_group(id=DEFAULT_GROUP_ID, created=datetime(2023, 5, 10), packages=['foo'], affected='1.2.3-3')
 def test_index_vulnerable_json(db, client):
     resp = client.get(url_for('tracker.index_vulnerable_json'), follow_redirects=True)
     assert 200 == resp.status_code
     data = resp.get_json()
     assert len(data) == 1
     assert data[0]['name'] == DEFAULT_GROUP_NAME
+    assert data[0]['date'] == '2023-05-10'

--- a/tracker/view/index.py
+++ b/tracker/view/index.py
@@ -90,6 +90,7 @@ def index_json(only_vulnerable=False):
 
         json_entry = OrderedDict()
         json_entry['name'] = group.name
+        json_entry['date'] = group.created.strftime('%Y-%m-%d')
         json_entry['packages'] = entry['pkgs']
         json_entry['status'] = group.status.label
         json_entry['severity'] = group.severity.label

--- a/tracker/view/show.py
+++ b/tracker/view/show.py
@@ -282,6 +282,7 @@ def show_group_json(avg):
 
     json_data = OrderedDict()
     json_data['name'] = group.name
+    json_data['date'] = group.created.strftime('%Y-%m-%d')
     json_data['packages'] = [package.pkgname for package in packages]
     json_data['status'] = group.status.label
     json_data['severity'] = group.severity.label


### PR DESCRIPTION
Through the json interface currently there is no way to find when a group was created. If an app for example uses /issues/vulnerable.json and needs this information it currently additionally has to download the group html for each group and parse the "Created date" from the html.

This MR adds group.created as 'date' to the issues and group json so for example downloading /issues/vulnerable.json would include this information and no additional download for each group is needed.

It uses Y-m-d date format same as is used for advisories creation date in package json.