### PR TITLE
Fix Package template still linking to Flyspray instead of GitLab

### DIFF
--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -156,4 +156,17 @@ def create_app(script_info=None):
                     Advisory=Advisory, CVE=CVE, CVEGroup=CVEGroup, CVEGroupEntry=CVEGroupEntry,
                     CVEGroupPackage=CVEGroupPackage, User=User, Package=Package, oauth=oauth)
 
+    @app.template_filter('gitlab_encode')
+    def gitlab_encode(name: str) -> str:
+        '''Convert a Gitlab project name to variant which the Gitlab encodes in
+        its url / API for example mysql++ becomes mysqlplusplus.'''
+        from re import sub
+
+        name = sub(r'([a-zA-Z0-9]+)\+([a-zA-Z]+)', r'\1-\2', name)
+        name = sub(r'\+', r'plus', name)
+        name = sub(r'[^a-zA-Z0-9_\-\.]', r'-', name)
+        name = sub(r'[_\-]{2,}', r'-', name)
+        name = sub(r'^tree$', r'unix-tree', name)
+        return name
+
     return app

--- a/tracker/templates/package.html
+++ b/tracker/templates/package.html
@@ -76,8 +76,8 @@
 							{%- else -%}
 							<a href="https://www.archlinux.org/packages/?name={{ package.pkgname|urlencode }}">package</a> |
 							{%- endif %}
-							<a href="https://bugs.archlinux.org/?project=0&order=id&sort=desc&string={{ package.pkgname|urlencode }}">bugs open</a> |
-							<a href="https://bugs.archlinux.org/?project=0&order=id&sort=desc&status%5B%5D=closed&string={{ package.pkgname|urlencode }}">bugs closed</a> |
+							<a href="https://gitlab.archlinux.org/archlinux/packaging/packages/{{ package.pkgname|gitlab_encode }}/-/issues">bugs open</a> |
+							<a href="https://gitlab.archlinux.org/archlinux/packaging/packages/{{ package.pkgname|gitlab_encode }}/-/issues/?state=closed">bugs closed</a> |
 							<a href="https://wiki.archlinux.org/index.php/Special:Search?search=%22{{ package.pkgname|urlencode }}%22">Wiki</a> |
 							<a href="https://github.com/search?type=Repositories&q=%22{{ package.pkgname|urlencode }}%22">GitHub</a> |
 							<a href="https://www.google.net/search?gws_rd=cr&q=%22{{ package.pkgname|urlencode }}%22">web search</a>


### PR DESCRIPTION
Just a small change to fix some outdated links I found that still lead to bugs.archlinux.org instead of the GitLab.
I couldn't quickly figure out if and how a change like this is tested (almost all tests don't work on my machine even before the change), but the links should work fine like that.