### PR TITLE
tracker: migrate bug ticket creation to GitLab from Flyspray

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,22 +63,13 @@ def db(app, request):
 @pytest.fixture(autouse=True, scope='function')
 def run_scoped(app, db, client, request):
     with app.app_context():
-        connection = db.engine.connect()
-        transaction = connection.begin()
-
-        options = dict(bind=connection, binds={})
-        session = db.create_scoped_session(options=options)
-
-        db.session = session
         db.create_all()
 
         with client:
             yield
 
+        db.session.remove()
         db.drop_all()
-        transaction.rollback()
-        connection.close()
-        session.remove()
 
 
 @pytest.fixture(scope='function')

--- a/tracker/templates/group.html
+++ b/tracker/templates/group.html
@@ -53,7 +53,7 @@
 							{%- if group.bug_ticket %}
 						<td>{{ bug_ticket(group.bug_ticket) }}</td>
 							{%- elif group.status == "Vulnerable" %}
-						<td><a class='button button-table button-primary' href="https://bugs.archlinux.org/newtask?{{ bug_data | urlencode }}", accesskey='t'>Create</a></td>
+						<td><a class='button button-table button-primary' href="{{ url_for('tracker.create_bug_ticket_redirect', avg=group.name) }}" accesskey='t'>Create</a></td>
 							{%- else %}
 						<td>None</td>
 							{%- endif %}


### PR DESCRIPTION
Arch Linux no longer uses Flyspray for issue tracking. This commit updates the security tracker to generate GitLab issue URLs for package-specific vulnerability reports from the server side enabling users to create a fully populated bug report with a single click.


https://github.com/user-attachments/assets/d0637c94-c4d8-448f-a3fd-33ea2a64f556

Closes #222 and #223